### PR TITLE
Added espressif32 to target platforms

### DIFF
--- a/library.json
+++ b/library.json
@@ -17,5 +17,5 @@
     }    
   ],
   "frameworks": "arduino",
-  "platforms": "esp32"
+  "platforms": ["esp32", "espressif32"]
 }


### PR DESCRIPTION
PlatformIO needs recognises esp32 platform as espressif32 when in strict ldf mode.
This will ensure compatibilty.