### PR TITLE
Release 2.10

### DIFF
--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/rpolitex/ArduinoNvs"
   },
-  "version": "2.8",
+  "version": "2.9",
   "authors": [
     {
     "name": "dRKr",

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/rpolitex/ArduinoNvs"
   },
-  "version": "2.9",
+  "version": "2.10",
   "authors": [
     {
     "name": "dRKr",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ArduinoNvs
-version=2.9
+version=2.10
 author=dRKr <info@sinai.io>
 maintainer=SinaiRnD <www: www.sinai.io>
 sentence=Arduino wrapper for ESP32 NVS (Non-volatile storage)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ArduinoNvs
-version=2.8
+version=2.9
 author=dRKr <info@sinai.io>
 maintainer=SinaiRnD <www: www.sinai.io>
 sentence=Arduino wrapper for ESP32 NVS (Non-volatile storage)

--- a/src/ArduinoNvs.cpp
+++ b/src/ArduinoNvs.cpp
@@ -84,8 +84,10 @@ bool ArduinoNvs::begin(String namespaceNvs, nvs_sec_cfg_t *keys)
 
 bool ArduinoNvs::format() {
   const esp_partition_t *nvs_partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_NVS, NULL);
-  if (nvs_partition == NULL)
+  if (nvs_partition == NULL) {
+    DEBUG_PRINTLN("E: NVS. No NVS partition");
     return false;
+  }
   esp_err_t err = esp_partition_erase_range(nvs_partition, 0, nvs_partition->size);
   if (err != ESP_OK)
     DEBUG_PRINTF("E: NVS. Cannot format the partition [%d]\n", err);
@@ -262,12 +264,11 @@ bool ArduinoNvs::getString(String key, String &res)
   return true;
 }
 
-String ArduinoNvs::getString(String key)
-{
+String  ArduinoNvs::getString(String key, const char* default_value) {
   String res;
   bool ok = getString(key, res);
   if (!ok)
-    return String();
+    return String(default_value);
   return res;
 }
 

--- a/src/ArduinoNvs.cpp
+++ b/src/ArduinoNvs.cpp
@@ -94,9 +94,18 @@ bool ArduinoNvs::format() {
   return err == ESP_OK;
 }
 
-void ArduinoNvs::close()
+bool ArduinoNvs::close(bool deinit_partition)
 {
   nvs_close(_nvs_handle);
+  if (deinit_partition == false)
+    return true;
+  
+  // deinit parttion if needed  
+  esp_err_t err = nvs_flash_deinit();
+  if (err != ESP_OK)
+    DEBUG_PRINTF("W: NVS. Cannot deinit the partition [%d]\n", err);
+  
+  return err == ESP_OK;
 }
 
 bool ArduinoNvs::eraseAll(bool forceCommit)

--- a/src/ArduinoNvs.h
+++ b/src/ArduinoNvs.h
@@ -87,6 +87,7 @@ public:
   std::vector<uint8_t> getBlob(String key); /// Less eficient but more simple in usage implemetation of `getBlob()`
 
   bool    commit();
+  bool    format(); /// Format NVS parttion. WARNING: DESTROYS ALL NVS DATA!
   
 protected:
   nvs_handle  _nvs_handle;    

--- a/src/ArduinoNvs.h
+++ b/src/ArduinoNvs.h
@@ -43,10 +43,12 @@ extern "C" {
   #define DEBUG_PRINTLN(...) { }
   #define DEBUG_PRINTF(fmt, args...) { }
 #else
-  #define DEBUG_PRINTER Serial
-  #define DEBUG_PRINT(...) { DEBUG_PRINTER.print(__VA_ARGS__); }
-  #define DEBUG_PRINTLN(...) { DEBUG_PRINTER.println(__VA_ARGS__); }
-  #define DEBUG_PRINTF(fmt, args...) { DEBUG_PRINTER.printf(fmt,## args); }
+  #ifndef ANVS_DEBUG_PRINTER
+  #define ANVS_DEBUG_PRINTER Serial
+  #endif
+  #define DEBUG_PRINT(...) { ANVS_DEBUG_PRINTER.print(__VA_ARGS__); }
+  #define DEBUG_PRINTLN(...) { ANVS_DEBUG_PRINTER.println(__VA_ARGS__); }
+  #define DEBUG_PRINTF(fmt, args...) { ANVS_DEBUG_PRINTER.printf(fmt,## args); }
 #endif
 
 class ArduinoNvs {
@@ -54,6 +56,8 @@ public:
   ArduinoNvs();
 
   bool    begin(String namespaceNvs = "storage");
+  bool    begin(String namespaceNvs, nvs_sec_cfg_t *keys); /// use only for that rare cases, when you do not have NVS Key Partition, and store keys in external secure storage (or hardcode). See https://docs.espressif.com/projects/esp-idf/en/release-v5.0/esp32/api-reference/storage/nvs_flash.html#encrypted-read-write
+  
   void    close();
 
   bool    eraseAll(bool forceCommit = true);
@@ -82,9 +86,11 @@ public:
   bool    getBlob(String key, std::vector<uint8_t>& blob);  
   std::vector<uint8_t> getBlob(String key); /// Less eficient but more simple in usage implemetation of `getBlob()`
 
-  bool        commit();
+  bool    commit();
+  
 protected:
   nvs_handle  _nvs_handle;    
+  esp_err_t _init(nvs_sec_cfg_t *cfg);
 };
 
 extern ArduinoNvs NVS;

--- a/src/ArduinoNvs.h
+++ b/src/ArduinoNvs.h
@@ -79,7 +79,7 @@ public:
   float   getFloat(String key, float default_value = 0);
   
   bool    getString(String key, String& res);
-  String  getString(String key);
+  String  getString(String key, const char* default_value = "");
 
   size_t  getBlobSize(String key);  /// Returns the size of the stored blob
   bool    getBlob(String key,  uint8_t* blob, size_t length);  /// User should proivde enought memory to store the loaded blob. If length < than required size to store blob, function fails.
@@ -87,7 +87,7 @@ public:
   std::vector<uint8_t> getBlob(String key); /// Less eficient but more simple in usage implemetation of `getBlob()`
 
   bool    commit();
-  bool    format(); /// Format NVS parttion. WARNING: DESTROYS ALL NVS DATA!
+  static bool format(); /// Format NVS parttion. WARNING: DESTROYS ALL NVS DATA!
   
 protected:
   nvs_handle  _nvs_handle;    

--- a/src/ArduinoNvs.h
+++ b/src/ArduinoNvs.h
@@ -58,7 +58,7 @@ public:
   bool    begin(String namespaceNvs = "storage");
   bool    begin(String namespaceNvs, nvs_sec_cfg_t *keys); /// use only for that rare cases, when you do not have NVS Key Partition, and store keys in external secure storage (or hardcode). See https://docs.espressif.com/projects/esp-idf/en/release-v5.0/esp32/api-reference/storage/nvs_flash.html#encrypted-read-write
   
-  void    close();
+  bool    close(bool deinit_partition = false);
 
   bool    eraseAll(bool forceCommit = true);
   bool    erase(String key, bool forceCommit = true);
@@ -97,4 +97,3 @@ protected:
 extern ArduinoNvs NVS;
 
 #endif
-


### PR DESCRIPTION
## Overview ##
1. Support for specific encryption-related use-cases: 
    - non-encrypted NVS on Encryption-enabled system
    - use encryption keys, not stored in the key-partition
1. Added default value to `getString()`
1. Added `format()` function to clear and format the whole NVS partition
1. Added optional partition de-init during `close()`


## Support for specific encryption-related use-cases ##
There are some cases when `nvs_flash_init()` works not perfectly:
1. You need access to Non-encrypted NVS on Encryption-enabled system (CONFIG_NVS_ENCRYPTION=1).
   Use usual `begin(String namespaceNvs)`.
2. You store NVS keys in external secure storage (or hardcoded)   (instead of in NVS Key Partition).
       Use `begin(String namespaceNvs, nvs_sec_cfg_t *keys)`.   See some details [here](https://docs.espressif.com/projects/esp-idf/en/release-v5.0/esp32/api-reference/storage/nvs_flash.html#encrypted-read-write). 
       NOTE: You cannot use encrypted and non-encrypted NVS namespaces simultaneously (because ArduinoNvs uses one NVS_DEFAULT_PART_NAME partition for all namespaces).
 
```c++
// Example with hardcoded keys
    nvs_sec_cfg_t keys = {
        .eky = {1, 2, 3, 4, 5},
        .tky = {6, 7, 8, 9, 10}
    };
    ArduinoNvs E;
    E.begin("TEST1", &keys));

    // use lib as usual
```



